### PR TITLE
🐛Add missing "capture" attribute

### DIFF
--- a/inputfiles/idl/HTML - The input element.widl
+++ b/inputfiles/idl/HTML - The input element.widl
@@ -5,6 +5,7 @@ interface HTMLInputElement : HTMLElement {
   [CEReactions] attribute DOMString alt;
   [CEReactions] attribute DOMString autocomplete;
   [CEReactions] attribute boolean autofocus;
+  [CEReactions] attribute DOMString capture;
   [CEReactions] attribute boolean defaultChecked;
   attribute boolean checked;
   [CEReactions] attribute DOMString dirName;


### PR DESCRIPTION
Generated from [w3 spec](https://www.w3.org/TR/html-media-capture/#idl-def-htmlinputelement-partial-1)